### PR TITLE
Replace libm fabsf with .abs() and add micromath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
@@ -316,6 +316,12 @@ dependencies = [
  "num-complex",
  "static_assertions",
 ]
+
+[[package]]
+name = "micromath"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
 name = "nb"
@@ -563,6 +569,7 @@ dependencies = [
  "libm",
  "log",
  "microfft",
+ "micromath",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ formant-shifting = ["cepstral-smoothing"]
 debug-logging = []
 
 [dependencies]
+micromath = { version = "2.1", default-features = false }
 libm = "0.2.8"
 microfft = "0.6"
 

--- a/src/audio/frequencies.rs
+++ b/src/audio/frequencies.rs
@@ -1,5 +1,3 @@
-use libm::fabsf;
-
 pub const C_MAJOR_SCALE_STEPS: [usize; 7] = [0, 2, 4, 5, 7, 9, 11];
 pub const MAX_OCTAVES: usize = 10;
 
@@ -139,11 +137,11 @@ pub const FREQUENCIES: [&[f32]; 24] = [
 
 pub fn find_nearest_note_frequency(input_frequency: f32) -> f32 {
     let mut nearest_frequency = C_MAJOR_SCALE_FREQUENCIES[0];
-    let mut min_difference = fabsf(input_frequency - nearest_frequency);
+    let mut min_difference = (input_frequency - nearest_frequency).abs();
 
     for &scale in &FREQUENCIES {
         for &frequency in scale {
-            let difference = fabsf(input_frequency - frequency);
+            let difference = (input_frequency - frequency).abs();
             if difference < min_difference {
                 min_difference = difference;
                 nearest_frequency = frequency;
@@ -156,10 +154,10 @@ pub fn find_nearest_note_frequency(input_frequency: f32) -> f32 {
 
 pub fn find_nearest_note_in_key(input_frequency: f32, key_frequencies: &[f32]) -> f32 {
     let mut nearest_frequency = key_frequencies[0];
-    let mut min_difference = fabsf(input_frequency - nearest_frequency);
+    let mut min_difference = (input_frequency - nearest_frequency).abs();
 
     for &frequency in key_frequencies {
-        let difference = fabsf(input_frequency - frequency);
+        let difference = (input_frequency - frequency).abs();
         if difference < min_difference {
             min_difference = difference;
             nearest_frequency = frequency;

--- a/src/audio/oscillator.rs
+++ b/src/audio/oscillator.rs
@@ -34,10 +34,7 @@ impl Oscillator {
         }
 
         match self.waveform {
-            Waveform::Sine => {
-                // Optional: precompute a sine table for no_std
-                libm::sinf(2.0 * core::f32::consts::PI * self.phase)
-            }
+            Waveform::Sine => libm::sinf(2.0 * core::f32::consts::PI * self.phase),
             Waveform::Saw => 2.0 * self.phase - 1.0,
             Waveform::Square => {
                 if self.phase < 0.5 {
@@ -46,7 +43,7 @@ impl Oscillator {
                     -1.0
                 }
             }
-            Waveform::Triangle => 4.0 * libm::fabsf(self.phase - 0.5) - 1.0,
+            Waveform::Triangle => 4.0 * (self.phase - 0.5).abs() - 1.0,
         }
     }
 }

--- a/src/dsp/frequency_analysis.rs
+++ b/src/dsp/frequency_analysis.rs
@@ -1,6 +1,6 @@
 use core::f32::consts::PI;
 
-use libm::{atan2f, cosf, fabsf, floorf, fmodf, roundf, sinf, sqrtf};
+use libm::{atan2f, cosf, floorf, fmodf, roundf, sinf, sqrtf};
 
 use crate::audio::find_nearest_note_frequency;
 
@@ -140,7 +140,7 @@ pub fn bitcrush(sample: f32, bit_depth: i8) -> f32 {
 
 #[inline(always)]
 pub fn normalize_sample(sample: f32, target_peak: f32) -> f32 {
-    let abs_sample = fabsf(sample);
+    let abs_sample = sample.abs();
     if abs_sample > target_peak {
         // Scale the sample down to target_peak while preserving its sign.
         sample * (target_peak / abs_sample)

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -1,4 +1,4 @@
-use libm::{expf, fabsf, floorf, sqrtf};
+use libm::{expf, floorf, sqrtf};
 
 use crate::{
     MusicalSettings, VocalEffectsConfig,
@@ -136,7 +136,7 @@ where
         sample *= analysis_window_buffer[i];
         if sample.abs() > 0.95 {
             let sign = if sample >= 0.0 { 1.0 } else { -1.0 };
-            let compressed = 0.95 - 0.05 * expf(-fabsf(sample));
+            let compressed = 0.95 - 0.05 * expf(-sample.abs());
             sample = sign * compressed;
         }
         output_samples[i] = sample;
@@ -469,7 +469,7 @@ where
         // Optional: soft clipping for safety
         if sample.abs() > 0.95 {
             let sign = if sample >= 0.0 { 1.0 } else { -1.0 };
-            let compressed = 0.95 - 0.05 * expf(-fabsf(sample));
+            let compressed = 0.95 - 0.05 * expf(-sample.abs());
             sample = sign * compressed;
         }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,6 +1,6 @@
 //! Mathematical utilities
 
-use libm::{expf, fabsf};
+use libm::expf;
 
 /// Clamp a value between min and max
 #[inline(always)]
@@ -27,7 +27,7 @@ pub fn is_power_of_two(n: usize) -> bool {
 }
 
 pub fn normalize_sample(sample: f32, target_peak: f32) -> f32 {
-    let abs_sample = fabsf(sample);
+    let abs_sample = sample.abs();
     if abs_sample > target_peak {
         // Soft limiting to prevent harsh clipping
         let ratio = target_peak / abs_sample;


### PR DESCRIPTION
Replace numerous uses of libm::fabsf with the built-in f32.abs() and remove corresponding imports to simplify code and rely on core intrinsics. Minor cleanup in oscillator (single-line Sine arm and triangle abs expression). Add micromath dependency to Cargo.toml (version 2.1, default-features = false) for potential lightweight math helpers.

## What does this PR do?

Brief description of the changes.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🔧 Refactor/cleanup

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy` passes
- [ ] Tested manually (if needed)

## Special considerations

- [ ] Works in `no_std` environments
- [ ] No performance regression
- [ ] Updated documentation/examples

## Notes

Any additional context or screenshots.
